### PR TITLE
Removed calls to maximizeAction

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ class Window(QtGui.QDialog):
     def setVisible(self, visible):
         # When we want to 'disappear' into the system tray.
         self.minimizeAction.setEnabled(visible)
-        self.maximizeAction.setEnabled(not self.isMaximized())
+        #self.maximizeAction.setEnabled(not self.isMaximized())
         self.restoreAction.setEnabled(self.isMaximized() or not visible)
         super(Window, self).setVisible(visible)
 
@@ -273,7 +273,7 @@ class Window(QtGui.QDialog):
     def createTrayIcon(self):
         self.trayIconMenu = QtGui.QMenu(self)
         self.trayIconMenu.addAction(self.minimizeAction)
-        self.trayIconMenu.addAction(self.maximizeAction)
+        #self.trayIconMenu.addAction(self.maximizeAction)
         self.trayIconMenu.addAction(self.restoreAction)
         self.trayIconMenu.addSeparator()
         self.trayIconMenu.addAction(self.quitAction)


### PR DESCRIPTION
This should fix https://github.com/robobenklein/openairplay/issues/10

Which I believe is caused by PyQt versions across ubuntu versions? Or maybe @robobenklein forgot to remove calls to self.maximizeAction

Either way, this fixed it for me.